### PR TITLE
Don't define boot2version in multiple translation units.

### DIFF
--- a/source/sys.c
+++ b/source/sys.c
@@ -13,6 +13,8 @@
 /* Variables */
 static const char certs_fs[] ATTRIBUTE_ALIGN(32) = "/sys/cert.sys";
 
+u32 boot2version;
+
 void __Sys_ResetCallback(void)
 {
 	/* Reboot console */

--- a/source/sys.h
+++ b/source/sys.h
@@ -1,7 +1,7 @@
 #ifndef _SYS_H_
 #define _SYS_H_
 
-u32 boot2version;
+extern u32 boot2version;
 /* Prototypes */
 bool isIOSstub(u8 ios_number);
 bool loadIOS(int ios);


### PR DESCRIPTION
Doesn't compile with the latest devkitpro without this patch... and to be quite honest I'm surprised it ever did? Either way.